### PR TITLE
Integrated projectile with towers in TowerCombatTask

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
@@ -97,8 +97,8 @@ public class ForestGameArea extends GameArea {
     spawnBuilding2();
     player = spawnPlayer();
 
-    spawnGhosts();
-    spawnGhostKing();
+    //spawnGhosts();
+  //  spawnGhostKing();
     spawnWeaponTower();
 //    spawnWall();
 
@@ -107,8 +107,8 @@ public class ForestGameArea extends GameArea {
 
     playMusic();
 
-    spawnProjectile(new Vector2(3f, 3f));
-    spawnMultiProjectile(new Vector2(3f, 3f));
+    //spawnProjectile(new Vector2(3f, 3f));
+   // spawnMultiProjectile(new Vector2(3f, 3f));
   }
 
   private void displayUI() {

--- a/source/core/src/main/com/csse3200/game/components/CostComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/CostComponent.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CostComponent extends Component {
 
-    private static final Logger logger = LoggerFactory.getLogger(CostComponent.class);
+
     private int cost;
 
     public CostComponent(int cost) {

--- a/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
@@ -3,6 +3,8 @@ package com.csse3200.game.components.tasks;
 import com.badlogic.gdx.math.Vector2;
 import com.csse3200.game.ai.tasks.DefaultTask;
 import com.csse3200.game.ai.tasks.PriorityTask;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.factories.ProjectileFactory;
 import com.csse3200.game.physics.PhysicsEngine;
 import com.csse3200.game.physics.PhysicsLayer;
 import com.csse3200.game.physics.raycast.RaycastHit;
@@ -109,6 +111,10 @@ public class TowerCombatTask extends DefaultTask implements PriorityTask {
                     towerState = STATE.STOW;
                 } else {
                     owner.getEntity().getEvents().trigger(FIRING);
+                    // this might be changed to an event which gets triggered everytime the tower enters the firing state
+                    Entity newProjectile = ProjectileFactory.createProjectile(null, owner.getEntity(), new Vector2(100, owner.getEntity().getPosition().y), new Vector2(2f,2f));
+                    newProjectile.setPosition((float) (owner.getEntity().getPosition().x + 0.75), (float) (owner.getEntity().getPosition().y + 0.75));
+                    ServiceLocator.getEntityService().register(newProjectile);
                 }
             }
             case STOW -> {

--- a/source/core/src/main/com/csse3200/game/entities/factories/TowerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/TowerFactory.java
@@ -41,7 +41,7 @@ public class TowerFactory {
     private static final String STOW_ANIM = "stow";
     private static final float STOW_SPEED = 0.2f;
     private static final String FIRE_ANIM = "firing";
-    private static final float FIRE_SPEED = 0.2f;
+    private static final float FIRE_SPEED = 0.25f;
     private static final baseTowerConfigs configs =
             FileLoader.readClass(baseTowerConfigs.class, "configs/tower.json");
 


### PR DESCRIPTION
Integrated projectile with towers so that the tower shoots mobs once it enters the firing state (Projectile team has to change their target layer to NPC). Also commented out excessive spawning of ghost entities. 