### PR TITLE
Team 2  alasdair branch

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
@@ -204,7 +204,7 @@ public class TowerCombatTask extends DefaultTask implements PriorityTask {
         float oldFireSpeed = 1/fireRateInterval;
         float newFireSpeed = oldFireSpeed + perMinute/60f;
         if (newFireSpeed == 0) {
-            fireRateInterval = 0;
+            return;
         } else {
             fireRateInterval = 1 / newFireSpeed;
         }

--- a/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/TowerCombatTask.java
@@ -203,7 +203,11 @@ public class TowerCombatTask extends DefaultTask implements PriorityTask {
     private void changeFireRateInterval(int perMinute) {
         float oldFireSpeed = 1/fireRateInterval;
         float newFireSpeed = oldFireSpeed + perMinute/60f;
-        fireRateInterval = 1/newFireSpeed;
+        if (newFireSpeed == 0) {
+            fireRateInterval = 0;
+        } else {
+            fireRateInterval = 1 / newFireSpeed;
+        }
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/entities/factories/TowerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/TowerFactory.java
@@ -117,8 +117,7 @@ public class TowerFactory {
                 .addComponent(new CostComponent(config.cost))
                 .addComponent(aiTaskComponent)
                 .addComponent(animator)
-                .addComponent(new TowerAnimationController())
-                .addComponent(new TowerUpgraderComponent());
+                .addComponent(new TowerAnimationController());
 
         return weapon;
 
@@ -132,7 +131,8 @@ public class TowerFactory {
         Entity tower = new Entity()
                 .addComponent(new ColliderComponent())
                 .addComponent(new HitboxComponent().setLayer(PhysicsLayer.OBSTACLE)) // TODO: we might have to change the names of the layers
-                .addComponent(new PhysicsComponent().setBodyType(BodyType.StaticBody));
+                .addComponent(new PhysicsComponent().setBodyType(BodyType.StaticBody))
+                .addComponent(new TowerUpgraderComponent());
 
         return tower;
     }

--- a/source/core/src/test/com/csse3200/game/components/tower/TowerUpgraderComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/tower/TowerUpgraderComponentTest.java
@@ -62,4 +62,20 @@ class TowerUpgraderComponentTest {
         verify(towerUpgraderComponent).upgradeTower(TowerUpgraderComponent.UPGRADE.FIRERATE, 60);
         assertEquals(0.5, towerCombatTask.getFireRateInterval());
     }
+
+    @Test
+    void divideByZeroDefaultToZero() {
+        entity.addComponent(towerUpgraderComponent);
+        AITaskComponent aiTaskComponent = new AITaskComponent();
+        ServiceLocator.registerPhysicsService(mock(PhysicsService.class));
+        ServiceLocator.registerTimeSource(mock(GameTime.class));
+        TowerCombatTask towerCombatTask = new TowerCombatTask(10, 10, 1);
+        aiTaskComponent.addTask(towerCombatTask);
+        entity.addComponent(aiTaskComponent);
+        towerCombatTask.start();
+        entity.create();
+        entity.getEvents().trigger("upgradeTower", TowerUpgraderComponent.UPGRADE.FIRERATE, -60);
+        verify(towerUpgraderComponent).upgradeTower(TowerUpgraderComponent.UPGRADE.FIRERATE, -60);
+        assertEquals(0., towerCombatTask.getFireRateInterval());
+    }
 }

--- a/source/core/src/test/com/csse3200/game/components/tower/TowerUpgraderComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/tower/TowerUpgraderComponentTest.java
@@ -64,7 +64,7 @@ class TowerUpgraderComponentTest {
     }
 
     @Test
-    void divideByZeroDefaultToZero() {
+    void divideByZeroDefaultToIgnore() {
         entity.addComponent(towerUpgraderComponent);
         AITaskComponent aiTaskComponent = new AITaskComponent();
         ServiceLocator.registerPhysicsService(mock(PhysicsService.class));
@@ -76,6 +76,6 @@ class TowerUpgraderComponentTest {
         entity.create();
         entity.getEvents().trigger("upgradeTower", TowerUpgraderComponent.UPGRADE.FIRERATE, -60);
         verify(towerUpgraderComponent).upgradeTower(TowerUpgraderComponent.UPGRADE.FIRERATE, -60);
-        assertEquals(0., towerCombatTask.getFireRateInterval());
+        assertEquals(1., towerCombatTask.getFireRateInterval());
     }
 }


### PR DESCRIPTION
Averts divide by zero edge case if a tower's fire rate is reduced to 0 shots per second. If TowerCombatTask attempts to set it's fireRateInterval to 1/0, it will instead be set to 0.
TowerUpgraderComponent is now part of all towers made, not just weapon towers.